### PR TITLE
ユーザー情報変更機能（サインアップ時）の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ LINEアプリでみんなが紹介したYouTube上の楽曲を、後からまと
 - macOS: Catalina 10.15.7（19H2）
 - Ruby: 2.6.5p114
 - Rails: 6.0.3.4
-- MySQL: 14.14
+- MySQL: 5.6.50
 - Node.js: 14.15.0
 - Yarn: 1.22.10
 

--- a/app/assets/stylesheets/layouts.css
+++ b/app/assets/stylesheets/layouts.css
@@ -1,3 +1,8 @@
 a {
   text-decoration: none;
 }
+
+input:checked + label img {
+  background-color: white;
+}
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :icon, :message])
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentization
     else
-      redirect_to root_path
+      render template: 'devise/registrations/new'
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+  before_action :check_omniauthed?, only: [:new]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  def create
+    if params[:user][:user_id]
+      pass = Devise.friendly_token
+      params[:user][:password] = pass
+      params[:user][:password_confirmation] = pass
+    end
+    super
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  private
+  def check_omniauthed?
+    redirect_to root_path unless @user
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,13 +13,13 @@ class User < ApplicationRecord
     validates :password
   end
 
-  has_many :posts
+  has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
 
   def self.from_omniauth(auth)
     pass = Devise.friendly_token
-    User.where(user_id: auth.uid).first_or_create(
+    User.where(user_id: auth.uid).first_or_initialize(
       user_id: auth.uid,
       name: auth.info.name,
       icon: auth.info.image,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,49 @@
+<div id="column">
+  <h2 class="text-center py-4 text-light" style="font-size: 50px;">あなたのプロフィール</h2>
+</div>
+
+<div class="container vh-100 mx-5 pl-5">
+  <div class="form-wrapper ml-5 pl-5">
+
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), class: "mx-5")  do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %><br><br>
+
+        <%= f.hidden_field :user_id, value: resource.user_id %>
+        <div class="form-group mb-4">
+          <%= f.label :name, "ニックネームの確認", class: "text-light mb-4", style: "font-size: 40px;" %>
+          <div class="col-10">
+            <%= f.text_field :name, class: "form-control", placeholder: "入力してね", style: "font-size: 30px;"%>
+          </div>
+        </div>
+
+        <fieldset class="form-group">
+            <legend class="col-form-label pt-0 text-light" style="font-size: 40px;">アイコンはどちらにする？</legend>
+            <div class="d-flex">
+              <div class="form-check">
+                  <%= f.radio_button :icon, resource.icon, style: "visibility: hidden;", id: "user_icon_1"%>
+                  <%= f.label :icon, (image_tag resource.icon, class: "img-fluid rounded-circle col-4 p-1", alt: "表示できません"), for: "user_icon_1" %>
+              </div>
+              <div class="form-check">
+                  <%= f.radio_button :icon, "https://user-images.githubusercontent.com/74892038/105449022-d0b30e00-5cba-11eb-833a-977e0846972d.png",style: "visibility: hidden;", id: "user_icon_2" %>
+                  <%= f.label :icon, (image_tag "https://user-images.githubusercontent.com/74892038/105449022-d0b30e00-5cba-11eb-833a-977e0846972d.png", class: "img-fluid rounded-circle col-4 p-1", alt: "表示できません"), for: "user_icon_2" %>
+              </div>
+            </div>
+        </fieldset>
+
+        <div class="form-group mb-5">
+          <div class="text-light mb-3" style="font-size: 40px;">ステータスメッセージを表示する？</div>
+          <div class="form-check">
+            <%= f.check_box :message, {checked: false}, resource.message, "" %>
+            <%= f.label :message, "表示する", class: "col-form-label text-white", style: "font-size: 35px;" %>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="actions">
+            <%= f.submit "登録する", class: "btn btn-danger d-block", style: "font-size: 30px;" %>
+          </div>
+        </div>
+    <% end %>
+  </div>  
+</div>
+

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" class="text-danger" style="font-size: 30px;">
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,7 @@
                 <li><%= link_to "マイページ", user_path(current_user), style: "font-size: 40px;" %></li>
                 <li><%= link_to "ユーザーの一覧", users_path, style: "font-size: 40px;" %></li>
                 <li><%= link_to "ログアウト", destroy_user_session_path, style: "font-size: 40px;", method: :delete %></li>
+                <li><%= link_to "アカウントの削除（取り消せません！）", user_registration_path, style: "font-size: 40px;", method: :delete %></li>
               <% end %>
             </ul>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
                 <li><%= link_to "マイページ", user_path(current_user), style: "font-size: 40px;" %></li>
                 <li><%= link_to "ユーザーの一覧", users_path, style: "font-size: 40px;" %></li>
                 <li><%= link_to "ログアウト", destroy_user_session_path, style: "font-size: 40px;", method: :delete %></li>
-                <li><%= link_to "アカウントの削除（取り消せません！）", user_registration_path, style: "font-size: 40px;", method: :delete %></li>
+                <li><%= link_to "※アカウントの削除", user_registration_path, style: "font-size: 40px;", method: :delete %></li>
               <% end %>
             </ul>
           </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed: 
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,9 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
+
+ja:
+ activerecord:
+   attributes:
+     user:
+       name: ニックネーム


### PR DESCRIPTION
## What
サインアップ時、ユーザー情報を変更できる機能を実装
（同時にアカウント削除機能も実装）

## Why
LINE認証後、基本はLINE上のプロフィールが登録されるが
選択肢を設けることで、気軽にサービスを試してもらうため
（削除機能も、気軽にサービスを試してもらうため導入）

## How
- 初回ログイン（サインアップ時）のみ、Newページが表示される
- 各種選択肢がある
  - ニックネームの入力フォーム
  - 画像を、LINEのものか、サイトで用意したものか選択するボタン
  - プロフィール表示するかの選択ボタン（デフォルトはoff）